### PR TITLE
Run examples and compile in OM

### DIFF
--- a/src/rtctools_channel_flow/modelica/Deltares/ChannelFlow/Hydraulic/Branches/Internal/PartialHomotopic.mo
+++ b/src/rtctools_channel_flow/modelica/Deltares/ChannelFlow/Hydraulic/Branches/Internal/PartialHomotopic.mo
@@ -20,16 +20,9 @@ partial model PartialHomotopic
   input SI.Stress wind_stress_v(nominal = 1e-1) = 0.0; // Wind stress in y (v, northing) direction (= 0.5*pi radians, 90 degrees)
   // Flow
   SI.VolumeFlowRate[n_level_nodes + 1] Q(each nominal = abs(Q_nominal));
-  // Water level new master
-//    SI.Position[n_level_nodes] H(
-//  min = cat(1,
-//            {max(H_b[1], H_b[2])},
-//            { max(H_b[1 + i], max(H_b[2 + i], H_b[3 + i])) for i in 0:n_level_nodes - 3 },
-//            {max(H_b[n_level_nodes - 1], H_b[n_level_nodes])}
-//  )
-//  );
-            //Old working commit
-  SI.Position[n_level_nodes] H(min = cat(1, max(H_b[1], H_b[2]), max(H_b[1:n_level_nodes - 2], max(H_b[2:n_level_nodes - 1], H_b[3:n_level_nodes])), max(H_b[n_level_nodes - 1], H_b[n_level_nodes])));
+  //Assumption: the minimum water level in the channel is at least the maximum bottom level at any part of the channel,
+  // thus for steep channels this assumption might be a bit restrictive, but operatinally still reasonable.
+  SI.Position[n_level_nodes] H(each min=max(H_b[1],H_b[n_level_nodes]));
   // Array of Bottom Levels
   parameter SI.Position[n_level_nodes] H_b;
   // Length

--- a/src/rtctools_channel_flow/modelica/Deltares/ChannelFlow/Hydraulic/Branches/Internal/PartialHomotopic.mo
+++ b/src/rtctools_channel_flow/modelica/Deltares/ChannelFlow/Hydraulic/Branches/Internal/PartialHomotopic.mo
@@ -20,14 +20,16 @@ partial model PartialHomotopic
   input SI.Stress wind_stress_v(nominal = 1e-1) = 0.0; // Wind stress in y (v, northing) direction (= 0.5*pi radians, 90 degrees)
   // Flow
   SI.VolumeFlowRate[n_level_nodes + 1] Q(each nominal = abs(Q_nominal));
-  // Water level
-    SI.Position[n_level_nodes] H(
-  min = cat(1,
-            {max(H_b[1], H_b[2])},
-            { max(H_b[1 + i], max(H_b[2 + i], H_b[3 + i])) for i in 0:n_level_nodes - 3 },
-            {max(H_b[n_level_nodes - 1], H_b[n_level_nodes])}
-  )
-  );
+  // Water level new master
+//    SI.Position[n_level_nodes] H(
+//  min = cat(1,
+//            {max(H_b[1], H_b[2])},
+//            { max(H_b[1 + i], max(H_b[2 + i], H_b[3 + i])) for i in 0:n_level_nodes - 3 },
+//            {max(H_b[n_level_nodes - 1], H_b[n_level_nodes])}
+//  )
+//  );
+            //Old working commit
+  SI.Position[n_level_nodes] H(min = cat(1, max(H_b[1], H_b[2]), max(H_b[1:n_level_nodes - 2], max(H_b[2:n_level_nodes - 1], H_b[3:n_level_nodes])), max(H_b[n_level_nodes - 1], H_b[n_level_nodes])));
   // Array of Bottom Levels
   parameter SI.Position[n_level_nodes] H_b;
   // Length

--- a/src/rtctools_channel_flow/modelica/Deltares/ChannelFlow/Hydraulic/Storage/Internal/PartialStorage.mo
+++ b/src/rtctools_channel_flow/modelica/Deltares/ChannelFlow/Hydraulic/Storage/Internal/PartialStorage.mo
@@ -14,7 +14,12 @@ partial model PartialStorage
   parameter SI.VolumeFlowRate Q_nominal = 1.0;
 equation
   der(V) / Q_nominal = (HQ.Q + sum(QForcing)) / Q_nominal;
+  /*
+  Note: this does not compile in OMEdit.
+  The following alternative compiles but is incompatible with pymoca
   for substance in 1:medium.n_substances loop
 	HQ.M[substance] / (Q_nominal * C_nominal[substance]) = (theta * der(V * HQ.C[substance]) + (1 - theta) * Q_nominal * der(HQ.C[substance]))  / (Q_nominal * C_nominal[substance]);
   end for;
+  */
+  HQ.M[:] / (Q_nominal * C_nominal[:]) = (theta * der(V * HQ.C[:]) + (1 - theta) * Q_nominal * der(HQ.C[:]))  / (Q_nominal * C_nominal[:]);
 end PartialStorage;

--- a/src/rtctools_channel_flow/modelica/Deltares/ChannelFlow/Hydraulic/Storage/Internal/PartialStorage.mo
+++ b/src/rtctools_channel_flow/modelica/Deltares/ChannelFlow/Hydraulic/Storage/Internal/PartialStorage.mo
@@ -14,6 +14,7 @@ partial model PartialStorage
   parameter SI.VolumeFlowRate Q_nominal = 1.0;
 equation
   der(V) / Q_nominal = (HQ.Q + sum(QForcing)) / Q_nominal;
-  HQ.M[:] / (Q_nominal * C_nominal[:]) = (theta * der(V * HQ.C[:]) + (1 - theta) * Q_nominal * der(HQ.C[:]))  / (Q_nominal * C_nominal[:]);
-
+  for substance in 1:medium.n_substances loop
+	HQ.M[substance] / (Q_nominal * C_nominal[substance]) = (theta * der(V * HQ.C[substance]) + (1 - theta) * Q_nominal * der(HQ.C[substance]))  / (Q_nominal * C_nominal[substance]);
+  end for;
 end PartialStorage;

--- a/src/rtctools_channel_flow/modelica/Deltares/ChannelFlow/Hydraulic/Structures/PumpUserEquationdH.mo
+++ b/src/rtctools_channel_flow/modelica/Deltares/ChannelFlow/Hydraulic/Structures/PumpUserEquationdH.mo
@@ -2,7 +2,7 @@ within Deltares.ChannelFlow.Hydraulic.Structures;
 
 model PumpUserEquationdH "PumpUserEquationdH"
   extends DischargeControlledStructure;
-  Modelica.SIunits.Position HW;
+  Modelica.Units.SI.Position HW;
   // Note: This block introduces a new state (HW).
   // This must be set via an equation. The choice of equation is up to the user.
   // Note: This block can be extended to support other head options

--- a/src/rtctools_channel_flow/modelica/Deltares/ChannelFlow/Hydraulic/Structures/package.order
+++ b/src/rtctools_channel_flow/modelica/Deltares/ChannelFlow/Hydraulic/Structures/package.order
@@ -1,2 +1,3 @@
 DischargeControlledStructure
 Pump
+PumpUserEquationdH

--- a/src/rtctools_channel_flow/modelica/Deltares/ChannelFlow/Internal/Functions/SmoothMin.mo
+++ b/src/rtctools_channel_flow/modelica/Deltares/ChannelFlow/Internal/Functions/SmoothMin.mo
@@ -7,5 +7,5 @@ function SmoothMin "Smooth Approximation of a Min() Function"
   input Real eps = Deltares.Constants.eps;
   output Real smooth_min;
 algorithm
-  smooth_min := -1.0 * Deltares.Functions.SmoothMax(a=-1.0 * a, b=-1.0 * b, eps=eps);
+  smooth_min := -1.0 * SmoothMax(a=-1.0 * a, b=-1.0 * b, eps=eps);
 end SmoothMin;

--- a/src/rtctools_channel_flow/modelica/Deltares/ChannelFlow/SimpleRouting/Reservoir/package.order
+++ b/src/rtctools_channel_flow/modelica/Deltares/ChannelFlow/SimpleRouting/Reservoir/package.order
@@ -1,2 +1,3 @@
 Reservoir
 Reservoir_turbine_out
+Reservoir_multi_io


### PR DESCRIPTION
The files are fixed such that the examples are running and they also compile in OM. For partial homotopic an assumption is used that the minimum water level should be at least as big as the largest bottom elevation anywhere in the channel. This might effect the function ranges and thus slightly the scaling. (it will be more conservative)