### PR TITLE
Introduce correctly named blocks for rectangular cross-sections.

### DIFF
--- a/src/rtctools_channel_flow/modelica/Deltares/ChannelFlow/Hydraulic/Branches/HomotopicRectangular.mo
+++ b/src/rtctools_channel_flow/modelica/Deltares/ChannelFlow/Hydraulic/Branches/HomotopicRectangular.mo
@@ -1,8 +1,7 @@
 within Deltares.ChannelFlow.Hydraulic.Branches;
 
-model HomotopicLinear
+model HomotopicRectangular
   /*
-  This block is depracated. Use homotopic rectangular instead!
   Note: The default medium is FreshWater.
   To use a different medium, decalre the choice in your model file, for example
   replaceable package MyMedium = Deltares.ChannelFlow.Media.SalineWater;
@@ -27,4 +26,4 @@ equation
   _cross_section = width .* (H .- H_b);
   // Compute Wetted Perimeter
   _wetted_perimeter = width .+ 2.0 * (H .- H_b);
-end HomotopicLinear;
+end HomotopicRectangular;

--- a/src/rtctools_channel_flow/modelica/Deltares/ChannelFlow/Hydraulic/Branches/Linear.mo
+++ b/src/rtctools_channel_flow/modelica/Deltares/ChannelFlow/Hydraulic/Branches/Linear.mo
@@ -1,5 +1,7 @@
 within Deltares.ChannelFlow.Hydraulic.Branches;
 
+//This block is deprecated. Use Linear Rectangular or linearizedSV instead.
+
 model Linear
   extends HomotopicLinear(theta = 0.0);
 end Linear;

--- a/src/rtctools_channel_flow/modelica/Deltares/ChannelFlow/Hydraulic/Branches/LinearRectangular.mo
+++ b/src/rtctools_channel_flow/modelica/Deltares/ChannelFlow/Hydraulic/Branches/LinearRectangular.mo
@@ -1,0 +1,5 @@
+within Deltares.ChannelFlow.Hydraulic.Branches;
+
+model LinearRectangular
+  extends HomotopicRectangular(theta = 0.0);
+end LinearRectangular;

--- a/src/rtctools_channel_flow/modelica/Deltares/ChannelFlow/Hydraulic/Branches/package.order
+++ b/src/rtctools_channel_flow/modelica/Deltares/ChannelFlow/Hydraulic/Branches/package.order
@@ -3,4 +3,6 @@ Linear
 LinearisedSV
 HomotopicLinear
 HomotopicTrapezoidal
+HomotopicRectangular
+LinearRectangular
 IDZ


### PR DESCRIPTION
The old blocks with the confusing name (linear) remain with a comment that they are deprecated.