### PR TITLE
Add entry point modelica library to project.toml file.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,3 +31,6 @@ include = [
   "/COPYING.LESSER",
   "/README.md",
 ]
+
+[project.entry-points."rtctools.libraries.modelica"]
+library_folder = "rtctools_channel_flow:modelica"


### PR DESCRIPTION
When moving to project.toml from setup.py the entry point of the modelica files was not added, therefore rtc-tools could not find the channel flow library.