### PR TITLE
Fix Pump dH type from Distance to Position

### DIFF
--- a/src/rtctools_channel_flow/modelica/Deltares/ChannelFlow/Hydraulic/Structures/Pump.mo
+++ b/src/rtctools_channel_flow/modelica/Deltares/ChannelFlow/Hydraulic/Structures/Pump.mo
@@ -6,7 +6,7 @@ model Pump "Pump"
   // If dH cannot be calculated directly from the upstream and downstream heads
   // use the PumpDynamicHead model instead
   parameter Integer head_option = 0;
-  Modelica.Units.SI.Distance dH;
+  Modelica.Units.SI.Position dH;
  
 equation
   if head_option == -1 then

--- a/src/rtctools_channel_flow/modelica/Deltares/ChannelFlow/Hydraulic/Structures/PumpUserEquationdH.mo
+++ b/src/rtctools_channel_flow/modelica/Deltares/ChannelFlow/Hydraulic/Structures/PumpUserEquationdH.mo
@@ -8,7 +8,7 @@ model PumpUserEquationdH "PumpUserEquationdH"
   // Note: This block can be extended to support other head options
   parameter Integer head_option = 2;
   // The default head option of 2 aligns with the notation used in hydraulic structures
-  Modelica.Units.SI.Distance dH;
+  Modelica.Units.SI.Position dH;
  
 equation
   if head_option == 2 then


### PR DESCRIPTION
## Summary

Declare the pump head difference `dH` as `Modelica.Units.SI.Position` rather than `Modelica.Units.SI.Distance` in `Pump.mo` and `PumpUserEquationdH.mo`.

`Distance` is `Length(min=0)`, but `dH` is a signed difference that is legitimately negative whenever the downstream head sits below the upstream head, so the non-negative bound is wrong for this quantity.

## Why it matters

Tools that enforce a type's default `min`/`max` as a hard variable bound, rather than only a post-solve consistency check, can report a spurious infeasibility at any timestep where the true head difference is negative — even though the model is fully determined and consistent.

`Position` is plain `Length` with no sign restriction, and matches the type already used for `HQUp.H`, `HQDown.H`, `H_sea`, and other head and level variables throughout this library.

## Test plan

- [x] Existing test suite passes
- [x] Models using `Pump` / `PumpUserEquationdH` still simulate/optimize as before

Verified against `rtc-tools` (this repo has no test suite of its own). All three `rtc-tools` examples that use `Structures.Pump` (`cascading_channels`, `goal_programming`, `mixed_integer`) solve successfully and produce byte-identical `timeseries_export.csv` before and after; their logs are identical too apart from wall-clock timestamps. Also the full test suite is unchanged.

Additionally, Claude generated a test case since `rtc-tools` has no model exercising `PumpUserEquationdH`. It solves on both versions with byte-identical output and drives `dH` negative to test the PR change.

🤖 Generated with [Claude Code](https://claude.com/claude-code) and edited/summarized by @kentrutan